### PR TITLE
Parametrize test function using pytest.mark.parametrize

### DIFF
--- a/tests/byzantium/precompiles/test_05_modexp.py
+++ b/tests/byzantium/precompiles/test_05_modexp.py
@@ -4,12 +4,21 @@ abstract: Test MODEXP (0x0000..0005)
     Tests the MODEXP precompile, located at address 0x0000..0005
 
 """
+from typing import List
+
 import pytest
 
-from ethereum_test_tools import Account, Environment, StateTestFiller, Transaction, to_address
+from ethereum_test_tools import (
+    Account,
+    Environment,
+    StateTestFiller,
+    TestAddress,
+    Transaction,
+    to_address,
+)
 
 
-def input(b: str, e: str, m: str, extra: str):
+def create_modexp_tx_data(b: str, e: str, m: str, extra: str):
     """
     Generates output for the MODEXP precompile, with the inputs `b` (base), `e` (exponent),
     `m` (modulus) and optionally extra bytes to append at the end of the call input
@@ -26,95 +35,103 @@ def input(b: str, e: str, m: str, extra: str):
     )
 
 
-# ModExp is available since Byzantium
 @pytest.mark.valid_from("Byzantium")
-def test_modexp(state_test: StateTestFiller):
+@pytest.mark.parametrize(
+    ["input", "output"],
+    [
+        # format: ([b, e, m, extraData?], output)
+        # Here, `b`, `e` and `m` are the inputs to the ModExp precompile
+        # The output is the expected output of the call
+        # The optional extraData is extra padded data at the end of the calldata to the precompile
+        (["", "", "02"], "0x01"),
+        (["", "", "0002"], "0x0001"),
+        (["00", "00", "02"], "0x01"),
+        (["", "01", "02"], "0x00"),
+        (["01", "01", "02"], "0x01"),
+        (["02", "01", "03"], "0x02"),
+        (["02", "02", "05"], "0x04"),
+        (["", "", ""], "0x"),
+        (["", "", "00"], "0x00"),
+        (["", "", "01"], "0x00"),
+        (["", "", "0001"], "0x0000"),
+        # Test cases from EIP 198 (Note: the cases where the call goes out-of-gas and the
+        # final test case are not yet tested)
+        pytest.param(
+            [
+                "03",
+                "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e",
+                "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            ],
+            "0000000000000000000000000000000000000000000000000000000000000001",
+            id="EIP-198-case1",
+        ),
+        pytest.param(
+            [
+                "",
+                "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e",
+                "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+            ],
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            id="EIP-198-case2",
+        ),
+        pytest.param(
+            [
+                "03",
+                "ffff",
+                "8000000000000000000000000000000000000000000000000000000000000000",
+                "07",
+            ],
+            "0x3b01b01ac41f2d6e917c6d6a221ce793802469026d9ab7578fa2e79e4da6aaab",
+            id="EIP-198-case3",
+        ),
+    ],
+)
+def test_modexp(state_test: StateTestFiller, input: List[str], output: str):
     """
     Test the MODEXP precompile
     """
     env = Environment()
-    pre = {"0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": Account(balance=1000000000000000000000)}
+    pre = {TestAddress: Account(balance=1000000000000000000000)}
     post = {}
 
     account = to_address(0x100)
 
-    # format: [b, e, m, output, extraData?]
-    # Here, `b`, `e` and `m` are the inputs to the ModExp precompile
-    # The output is the expected output of the call
-    # The optional extraData is extra padded data at the end of the calldata to the precompile
-    data = [
-        ["", "", "02", "0x01"],
-        ["", "", "0002", "0x0001"],
-        ["00", "00", "02", "0x01"],
-        ["", "01", "02", "0x00"],
-        ["01", "01", "02", "0x01"],
-        ["02", "01", "03", "0x02"],
-        ["02", "02", "05", "0x04"],
-        ["", "", "", "0x"],
-        ["", "", "00", "0x00"],
-        ["", "", "01", "0x00"],
-        ["", "", "0001", "0x0000"],
-        # Test cases from EIP 198 (Note: the cases where the call goes out-of-gas and the
-        # final test case are not yet tested)
-        [
-            "03",
-            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e",
-            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
-            "0000000000000000000000000000000000000000000000000000000000000001",
-        ],
-        [
-            "",
-            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2e",
-            "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
-            "0000000000000000000000000000000000000000000000000000000000000000",
-        ],
-        [
-            "03",
-            "ffff",
-            "8000000000000000000000000000000000000000000000000000000000000000",
-            "0x3b01b01ac41f2d6e917c6d6a221ce793802469026d9ab7578fa2e79e4da6aaab",
-            "07",
-        ],
-    ]
-
-    for entry in data:
-        pre[account] = Account(
-            code=(
-                # Store all CALLDATA into memory (offset 0)
-                """0x366000600037"""
-                +
-                # Setup stack to CALL into ModExp with the CALLDATA and CALL into it (+ pop value)
-                """60006000366000600060055AF150"""
-                +
-                # Store contract deployment code to deploy the returned data from ModExp as
-                # contract code (16 bytes)
-                """7F601038036010600039601038036000F300000000000000000000000000000000600052"""
-                +
-                # RETURNDATACOPY the returned data from ModExp into memory (offset 16 bytes)
-                """3D600060103E"""
-                +
-                # CREATE contract with the deployment code + the returned data from ModExp
-                """3D60100160006000F0"""
-                +
-                # STOP (handy for tracing)
-                "00"
-            )
+    pre[account] = Account(
+        code=(
+            # Store all CALLDATA into memory (offset 0)
+            """0x366000600037"""
+            +
+            # Setup stack to CALL into ModExp with the CALLDATA and CALL into it (+ pop value)
+            """60006000366000600060055AF150"""
+            +
+            # Store contract deployment code to deploy the returned data from ModExp as
+            # contract code (16 bytes)
+            """7F601038036010600039601038036000F300000000000000000000000000000000600052"""
+            +
+            # RETURNDATACOPY the returned data from ModExp into memory (offset 16 bytes)
+            """3D600060103E"""
+            +
+            # CREATE contract with the deployment code + the returned data from ModExp
+            """3D60100160006000F0"""
+            +
+            # STOP (handy for tracing)
+            "00"
         )
+    )
 
-        extra = ""
-        if len(entry) == 5:
-            extra = entry[4]
+    if len(input) < 4:
+        input.append("")
 
-        tx = Transaction(
-            ty=0x0,
-            nonce=0,
-            to=account,
-            data=input(entry[0], entry[1], entry[2], extra),
-            gas_limit=500000,
-            gas_price=10,
-            protected=True,
-        )
-        # Address of the contract which gets generated once the contract is invoked
-        post["0xa7f2bd73a7138a2dec709484ad9c3542d7bc7534"] = Account(code=entry[3])
+    tx = Transaction(
+        ty=0x0,
+        nonce=0,
+        to=account,
+        data=create_modexp_tx_data(*input),
+        gas_limit=500000,
+        gas_price=10,
+        protected=True,
+    )
+    # Address of the contract which gets generated once the contract is invoked
+    post["0xa7f2bd73a7138a2dec709484ad9c3542d7bc7534"] = Account(code=output)
 
-        state_test(env=env, pre=pre, post=post, txs=[tx])
+    state_test(env=env, pre=pre, post=post, txs=[tx])


### PR DESCRIPTION
Parametrizes the test function instead of looping over the test vectors within it.

This generates many more test cases and therefore more verbose pytest output. You may want to restrict the number of test cases when debugging locally, for example by specifying a single fork:
```
fill tests/byzantium/precompiles/test_05_modexp.py --fork Byzantium
```
Stopping execution upon the first failing test via `-x` is also useful.
