### PR TITLE
chore: fix mypy tox errors

### DIFF
--- a/tests/cancun/eip1153_tstore/test_tstorage_clear_after_tx.py
+++ b/tests/cancun/eip1153_tstore/test_tstorage_clear_after_tx.py
@@ -3,6 +3,8 @@ Ethereum Transient Storage EIP Tests
 https://eips.ethereum.org/EIPS/eip-1153
 """
 
+from typing import Optional
+
 import pytest
 
 from ethereum_test_tools import (
@@ -10,6 +12,7 @@ from ethereum_test_tools import (
     Alloc,
     Block,
     BlockchainTestFiller,
+    Bytecode,
     Environment,
     EVMCodeType,
     Initcode,
@@ -42,8 +45,7 @@ def test_tstore_clear_after_deployment_tx(
     init_code = Op.TSTORE(1, 1)
     deploy_code = Op.SSTORE(1, Op.TLOAD(1))
 
-    code = None
-
+    code: Optional[Container | Initcode] = None
     if evm_code_type == EVMCodeType.EOF_V1:
         code = Container.Init(
             deploy_container=Container.Code(deploy_code), initcode_prefix=init_code
@@ -88,8 +90,8 @@ def test_tstore_clear_after_tx(
     env = Environment()
 
     runtime_code = Op.SSTORE(1, Op.TLOAD(1)) + Op.TSTORE(1, 1)
-    code = None
 
+    code: Optional[Container | Bytecode] = None
     if evm_code_type == EVMCodeType.EOF_V1:
         code = Container.Code(runtime_code)
     else:


### PR DESCRIPTION
## 🗒️ Description
<!-- Brief description of the changes introduced by this PR -->

## 🔗 Related Issues
<!-- Reference any related issues using the GitHub issue number (e.g., Fixes #123) -->

## ✅ Checklist
- [ ] All: Set appropriate labels for the changes.
- [ ] All: Considered squashing commits to improve commit history.
- [ ] All: Added an entry to [CHANGELOG.md](/ethereum/execution-spec-tests/blob/main/docs/CHANGELOG.md).
- [ ] All: Considered updating the online docs in the [./docs/](/ethereum/execution-spec-tests/blob/main/docs/) directory.
- [ ] Tests: All converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been added to [converted-ethereum-tests.txt](/ethereum/execution-spec-tests/blob/main/converted-ethereum-tests.txt).
- [ ] Tests: A PR with removal of converted JSON/YML tests from [ethereum/tests](/ethereum/tests) have been opened.
- [ ] Tests: Included the type and version of evm t8n tool used to locally execute test cases:  e.g., ref with commit hash or geth 1.13.1-stable-3f40e65.
- [ ] Tests: Ran `mkdocs serve` locally and verified the auto-generated docs for new tests in the [Test Case Reference](https://ethereum.github.io/execution-spec-tests/main/tests/) are correctly formatted.
